### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ go install -v github.com/HuntDownProject/hednsextractor/cmd/hednsextractor@lates
 ## Usage
 
 ```bash
-usage -h
+hednsextractor -h
 ```
 
 ```


### PR DESCRIPTION
The usage section is missing the proper binary name (`hednsextractor -h` vs. `usage -h`).